### PR TITLE
Adding Handler to Get Endpoint

### DIFF
--- a/.github/workflows/test-build-lint.yml
+++ b/.github/workflows/test-build-lint.yml
@@ -1,4 +1,4 @@
-name: Testing, building, and running app
+name: Testing, Building, and Lint app
 on: [pull_request]
 jobs:
   build:
@@ -48,22 +48,25 @@ jobs:
     ## runs go test
     - name: Test
       run: make test
-  # run:
-  #   strategy:
-  #     matrix:
-  #       go-version: [1.17.x]
-  #       platform: [ubuntu-latest]
+  lint:
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        platform: [ubuntu-latest]
     
-  #   runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}
 
-  #   steps:
-  #   - name: Install Go
-  #     uses: actions/setup-go@v2
-  #     with:
-  #       go-version: ${{ matrix.go-version }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
 
-  #   - name: Checkout code
-  #     uses: actions/checkout@v2
-    
-  #   - name: Run
-  #     run: make run
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+
+    - name: Lint
+      run: make lint

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,5 @@ run:
 	@go run main.go
 test:
 	@go test -v ./...
+lint:
+	@golangci-lint run

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,8 +1,92 @@
 package handler
 
 import (
+	"encoding/json"
+	"net/http"
+
 	"github.com/gofiber/fiber/v2"
 )
+
+type Person struct {
+	Sammy UserID `json:"Sammy"`
+	Jesse UserID `json:"Jesse"`
+	Drew  UserID `json:"Drew"`
+	Jamie UserID `json:"Jamie"`
+}
+
+type UserID struct {
+	Username  string `json:"Username"`
+	Followers int    `json:"Followers"`
+}
+
+type FollowerResult struct {
+	Followers int
+}
+
+func Follower(c *fiber.Ctx) error {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://jsonkeeper.com/b/DMXK", nil)
+	if err != nil {
+		return c.SendString(err.Error())
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return c.SendString(err.Error())
+	}
+	defer resp.Body.Close()
+
+	decoder := json.NewDecoder(resp.Body)
+	var p Person
+	err = decoder.Decode(&p)
+	if err != nil {
+		return c.SendString(err.Error())
+	}
+
+	switch c.Params("userid") {
+	case "SammyShark":
+		f := FollowerResult{p.Sammy.Followers}
+		return c.JSON(f)
+	case "JesseOctopus":
+		f := FollowerResult{p.Jesse.Followers}
+		return c.JSON(f)
+	case "DrewSquid":
+		f := FollowerResult{p.Drew.Followers}
+		return c.JSON(f)
+	case "JamieMantisShrimp":
+		f := FollowerResult{p.Jamie.Followers}
+		return c.JSON(f)
+	default:
+		return fiber.ErrNotFound
+	}
+}
+
+func Detail(c *fiber.Ctx) error {
+	resp, err := http.Get("https://jsonkeeper.com/b/DMXK")
+	if err != nil {
+		return c.SendString(err.Error())
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	var p Person
+	err = decoder.Decode(&p)
+	if err != nil {
+		return c.SendString(err.Error())
+	}
+
+	switch c.Params("userid") {
+	case "sammy":
+		return c.JSON(p.Sammy)
+	case "jesse":
+		return c.JSON(p.Jesse)
+	case "drew":
+		return c.JSON(p.Drew)
+	case "jamie":
+		return c.JSON(p.Jamie)
+	default:
+		return fiber.ErrNotFound
+	}
+}
 
 func CetakHello(c *fiber.Ctx) error {
 	return c.SendString("Hello, World!")

--- a/router/router.go
+++ b/router/router.go
@@ -19,9 +19,17 @@ func Router(app *fiber.App) {
 
 	port := os.Getenv("PORT")
 	hello_route(app)
-	app.Listen(":" + port)
+	user_route(app)
+	if err := app.Listen(":" + port); err != nil {
+		panic(err)
+	}
 }
 
 func hello_route(hello *fiber.App) {
 	hello.Get("/", handler.CetakHello)
+}
+
+func user_route(app *fiber.App) {
+	app.Get("/follower/:userid", handler.Follower)
+	app.Get("/:userid/detail", handler.Detail)
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert" // add Testify package
 )
 
-func TestHelloRoute(t *testing.T) {
+func TestRouter(t *testing.T) {
 	// Define a structure for specifying input and output data
 	// of a single test case
 	tests := []struct {
@@ -24,6 +24,18 @@ func TestHelloRoute(t *testing.T) {
 		},
 		// Second test case
 		{
+			description:  "get HTTP status 200",
+			route:        "/follower/SammyShark",
+			expectedCode: 200,
+		},
+		// Third test case
+		{
+			description:  "get HTTP status 200",
+			route:        "/sammy/detail",
+			expectedCode: 200,
+		},
+		// Fourth test case
+		{
 			description:  "get HTTP status 404, when route is not exists",
 			route:        "/not-found",
 			expectedCode: 404,
@@ -35,6 +47,7 @@ func TestHelloRoute(t *testing.T) {
 
 	// Create route with GET method for test
 	hello_route(app)
+	user_route(app)
 	// Iterate through test single test cases
 	for _, test := range tests {
 		// Create a new http request with the route from the test case
@@ -43,8 +56,10 @@ func TestHelloRoute(t *testing.T) {
 		// Perform the request plain with the app,
 		// the second argument is a request latency
 		// (set to -1 for no latency)
-		resp, _ := app.Test(req, 1)
-
+		resp, err := app.Test(req, 5000)
+		if err != nil {
+			t.Errorf("Error %v", err)
+		}
 		// Verify, if the status code is as expected
 		assert.Equalf(t, test.expectedCode, resp.StatusCode, test.description)
 	}


### PR DESCRIPTION
Adding lint job for github action on test-build-lint.yaml
 >this job will run action golangci lint
Adding person userid and follower strcut on handler.go
 >person and userid struct is used for hold json data when parsing json data from request body to struct
 >FollowerResult struct is use for follower endpoint response
Adding Follower() function on handler.go
 >this function will call external endpoint and parsing json req body to a struct
 >after parsing then will return json response which contain follower data based on username
Adding Detail function on handler.go
 >this function same as follower but will return json response which contain username and follower based on userid
Adding new test case for detail and follower route on router_test.go
Adding follower and detail route as endpoint on router.go
 >follower route will run Follower function from package handler
 >detail route will run Detail function from package handler